### PR TITLE
test(demo): add popup tables controlled by buttons

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -50,3 +50,72 @@
     padding-bottom: 42px;
   }
 }
+
+/* table modal (background) */
+.modal {
+  display: none;
+  position: fixed;
+  z-index: 999;
+  padding-top: 4em;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: scroll;
+  background-color: white;
+}
+
+.modal-open {
+  color: #ffffff;
+  background-color: #2d63c8;
+  border: 1px solid #2d63c8;
+  padding: 10px;
+  cursor: pointer
+}
+
+.modal-open:hover {
+  color: #2d63c8;
+  background-color: #ffffff;
+}
+
+/* modal table content */
+.modal-table-content {
+  position: relative;
+  margin: auto;
+  padding: 32px 16px 48px;
+  overflow: auto;
+  display: block;
+  white-space: nowrap;
+}
+
+/* close button for popup table */
+.modal-close {
+  color: black;
+  background-color: white;
+  position: absolute;
+  top: .5em;
+  right: .5em;
+  font-size: 2em;
+  font-weight: bold;
+  height: 1em;
+  width: 1em;
+  text-indent: 10em;
+  overflow: hidden;
+  border: 0;
+}
+
+.modal-close::after {
+  position: absolute;
+  line-height: 0.5;
+  top: 0.2em;
+  left: 0.1em;
+  text-indent: 0;
+  content: "\00D7"
+}
+
+.modal-close:hover,
+.modal-close:focus {
+  color: #999;
+  text-decoration: none;
+  cursor: pointer;
+}

--- a/content/en/cicd-security-guide/Phase 2/ssdf/ssdf-po/_index.md
+++ b/content/en/cicd-security-guide/Phase 2/ssdf/ssdf-po/_index.md
@@ -13,3 +13,43 @@ description: >
 
 Use automation to reduce human effort and improve the accuracy, reproducibility, usability, and comprehensiveness of security practices throughout the SDLC, as well as provide a way to document and demonstrate the use of these practices. Toolchains and tools may be used at different levels of the organization, such as organization-wide or project-specific, and may address a particular part of the SDLC, like a build pipeline.
 
+&nbsp;
+
+{{% table-popup table_name="Test Table" %}}
+<table class="modal-table-content">
+    <thead>
+        <tr>
+            <th>Column 1</th>
+            <th>Column 2</th>
+            <th>Column 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Reproducible and Deterministic Builds</td>
+            <td>Ensure that software artifacts can be independently verified and reproduced to prevent tampering.</td>
+            <td><i class="fa-solid fa-circle-xmark" style="color: #ff0000;"></i></td>
+        </tr>
+        <tr>
+            <td>Automated Threat Detection and Compliance Enforcement</td>
+            <td>Integrate continuous security analysis to detect misconfigurations, vulnerabilities, and unauthorized dependencies before deployment.</td>
+            <td><i class="fa-solid fa-circle-xmark" style="color: #ff0000;"></i></td>
+        </tr>
+        <tr>
+            <td>Policy-Enforced Deployments</td>
+            <td>Enforce verifiable security policies ensuring only compliant, attested software reaches production.</td>
+            <td><i class="fa-solid fa-circle-check" style="color: #008000;"></i></td>
+        </tr>
+        <tr>
+            <td>Trusted Execution Environments (TEEs)</td>
+            <td>Secure build environments against tampering using hardware-backed execution environments.</td>
+            <td><i class="fa-solid fa-circle-check" style="color: #008000;"></i></td>
+        </tr>
+        <tr>
+            <td>Cryptographic Attestation</td>
+        <td>Use digital signatures and cryptographic proofs to verify the authenticity and integrity of builds and deployments.</td>
+            <td><i class="fa-solid fa-circle-check" style="color: #008000;"></i></td>
+        </tr>
+    </tbody>
+</table>
+{{% /table-popup %}}

--- a/layouts/shortcodes/table-popup.html
+++ b/layouts/shortcodes/table-popup.html
@@ -1,0 +1,24 @@
+<!-- table modal -->
+<button class="modal-open" onclick="openModal()">Open {{ .Params.table_name }}</button>
+<div id="table-modal" class="modal">
+    <button class="modal-close" onclick="closeModal()">Close {{ .Params.table_name }}</button>
+    {{.Inner}}
+</div>
+
+<script>
+  // Open modal
+  function openModal() {
+    document.getElementById("table-modal").style.display = "block";
+    // Ensures the site footer is not shown if front of the modal. Remove if this is not an issue or
+    // there is no footer. "site-footer" id can also be changed appropriately.
+    // document.getElementById("site-footer").style.display = "hidden";
+  }
+
+  // Close modal
+  function closeModal() {
+    // prevents flashing last modal image while new id is loading on open
+    // document.getElementById("modalTable").innerHTML = "";
+    document.getElementById("table-modal").style.display = "none";
+    // document.getElementById("site-footer").style.display = "block";
+  }
+</script>


### PR DESCRIPTION
Following up on a discussion with Kate. Tested that it is indeed possible to have a popup implemented to show a scrollable table which can be controlled (opened or closed) with buttons. 

### Button placement
![Screenshot 2025-03-23 at 5 14 02 AM](https://github.com/user-attachments/assets/853e9e4a-e87d-4040-abba-d127cdd6e065)

### Table in popup
![Screenshot 2025-03-23 at 5 14 11 AM](https://github.com/user-attachments/assets/6ece631e-f2e1-452c-b718-02ba67b20a48)

### Table with icons
![Screenshot 2025-03-23 at 5 15 30 AM](https://github.com/user-attachments/assets/e07f39e7-d036-4629-a583-c45693c35959)